### PR TITLE
Fix: Grid の gap prop がセマンティックトークンを受け付けない

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -2,6 +2,15 @@ import { forwardRef, type CSSProperties, type HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 
 export type GridColumns = 1 | 2 | 3 | 4 | 5 | 6;
+export type GridGap = "xs" | "sm" | "md" | "lg" | "xl" | (string & {});
+
+const GAP_MAP: Record<string, string> = {
+  xs: "var(--space-1)",
+  sm: "var(--space-2)",
+  md: "var(--space-4)",
+  lg: "var(--space-6)",
+  xl: "var(--space-8)",
+};
 
 export interface GridProps extends HTMLAttributes<HTMLDivElement> {
   /** Column count at desktop (default) */
@@ -10,8 +19,8 @@ export interface GridProps extends HTMLAttributes<HTMLDivElement> {
   columnsMd?: GridColumns;
   /** Column count at ≤640px */
   columnsSm?: GridColumns;
-  /** Gap between items — any CSS value */
-  gap?: string;
+  /** Gap between items — semantic token ("sm", "md", etc.) or any CSS value */
+  gap?: GridGap;
 }
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>(
@@ -21,7 +30,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       ...(columns != null ? { "--grid-cols": columns } : {}),
       ...(columnsMd != null ? { "--grid-cols-md": columnsMd } : {}),
       ...(columnsSm != null ? { "--grid-cols-sm": columnsSm } : {}),
-      ...(gap != null ? { "--grid-gap": gap } : {}),
+      ...(gap != null ? { "--grid-gap": GAP_MAP[gap] ?? gap } : {}),
     } as CSSProperties;
 
     return (


### PR DESCRIPTION
## Summary
- `Grid` の `gap` prop にセマンティックトークン (`xs`/`sm`/`md`/`lg`/`xl`) を追加
- `GAP_MAP` でトークンを CSS カスタムプロパティに解決
- 生の CSS 値 (`"20px"` 等) も引き続き使用可能

## Test plan
- [ ] `gap="md"` で `var(--space-4)` が適用されること
- [ ] `gap="20px"` のような生の値も引き続き動作すること
- [ ] TypeScript の型補完で `xs`/`sm`/`md`/`lg`/`xl` が候補に出ること

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)